### PR TITLE
Handle models without timestamp config

### DIFF
--- a/insanely_fast_whisper_api/core/asr_backend.py
+++ b/insanely_fast_whisper_api/core/asr_backend.py
@@ -173,6 +173,16 @@ class HuggingFaceBackend(ASRBackend):  # pylint: disable=too-few-public-methods
                 )
                 _return_timestamps_value = False
 
+        if _return_timestamps_value:
+            gen_cfg = getattr(self.asr_pipe.model, "generation_config", None)
+            no_ts_token_id = getattr(gen_cfg, "no_timestamps_token_id", None)
+            if no_ts_token_id is None:
+                logger.warning(
+                    "Timestamp generation not properly configured for model %s; disabling.",
+                    self.config.model_name,
+                )
+                _return_timestamps_value = False
+
         # These are the arguments that will be passed to the pipeline
         # Suppress noisy warnings from HF transformers related to experimental chunk_length and deprecations.
         warnings.filterwarnings(

--- a/tests/test_asr_backend_timestamp.py
+++ b/tests/test_asr_backend_timestamp.py
@@ -1,0 +1,43 @@
+import types
+import pathlib
+
+from insanely_fast_whisper_api.core.asr_backend import HuggingFaceBackend, HuggingFaceBackendConfig
+
+
+def test_disables_timestamps_when_generation_config_missing(monkeypatch, tmp_path):
+    config = HuggingFaceBackendConfig(
+        model_name="dummy-model",
+        device="cpu",
+        dtype="float32",
+        batch_size=1,
+        chunk_length=30,
+    )
+    backend = HuggingFaceBackend(config)
+
+    class DummyModel:
+        generation_config = types.SimpleNamespace(no_timestamps_token_id=None)
+        config = types.SimpleNamespace(lang_to_id=None, task_to_id=None)
+
+    class DummyPipe:
+        def __init__(self):
+            self.model = DummyModel()
+
+        def __call__(self, path, **kwargs):
+            assert kwargs["return_timestamps"] is False
+            return {"text": "hello"}
+
+    backend.asr_pipe = DummyPipe()
+
+    monkeypatch.setattr(
+        "insanely_fast_whisper_api.audio.conversion.ensure_wav",
+        lambda p: pathlib.Path(p),
+    )
+
+    audio_file = tmp_path / "audio.wav"
+    audio_file.write_bytes(b"0")
+
+    result = backend.process_audio(
+        str(audio_file), language=None, task="transcribe", return_timestamps_value=True
+    )
+
+    assert result["chunks"] is None


### PR DESCRIPTION
## Summary
- Disable timestamp generation when model generation_config lacks required attributes
- Add unit test to ensure timestamps are turned off when unsupported

## Testing
- `pytest tests/test_asr_backend_timestamp.py -q`
- `pytest -q` *(fails: missing test data and GPU support)*

------
https://chatgpt.com/codex/tasks/task_e_68a70ea366ac832bb35dc997b8686dd3