### PR TITLE
Handle models without timestamp or task config

### DIFF
--- a/insanely_fast_whisper_api/core/asr_backend.py
+++ b/insanely_fast_whisper_api/core/asr_backend.py
@@ -173,6 +173,16 @@ class HuggingFaceBackend(ASRBackend):  # pylint: disable=too-few-public-methods
                 )
                 _return_timestamps_value = False
 
+        if _return_timestamps_value:
+            gen_cfg = getattr(self.asr_pipe.model, "generation_config", None)
+            no_ts_token_id = getattr(gen_cfg, "no_timestamps_token_id", None)
+            if no_ts_token_id is None:
+                logger.warning(
+                    "Timestamp generation not properly configured for model %s; disabling.",
+                    self.config.model_name,
+                )
+                _return_timestamps_value = False
+
         # These are the arguments that will be passed to the pipeline
         # Suppress noisy warnings from HF transformers related to experimental chunk_length and deprecations.
         warnings.filterwarnings(
@@ -215,13 +225,31 @@ class HuggingFaceBackend(ASRBackend):  # pylint: disable=too-few-public-methods
                 self.config.model_name,
             )
 
-        # Always add task and language parameters so Whisper knows we want translation.
-        pipeline_kwargs["generate_kwargs"]["task"] = task
-        # If translate task and no explicit language provided, default to English
-        if language and language.lower() != "none":
-            pipeline_kwargs["generate_kwargs"]["language"] = language
-        elif task == "translate":
-            pipeline_kwargs["generate_kwargs"]["language"] = "en"
+        # Older checkpoints may ship with generation configs that predate the
+        # introduction of task/language mappings. Passing "task" or "language"
+        # to such models triggers a ValueError. Only forward these parameters
+        # when the generation config exposes the required attributes.
+        gen_cfg = getattr(self.asr_pipe.model, "generation_config", None)
+        has_task_mappings = False
+        if gen_cfg is not None:
+            has_task_mappings = any(
+                getattr(gen_cfg, attr, None) is not None
+                for attr in ("task_to_id", "lang_to_id")
+            )
+
+        if has_task_mappings:
+            pipeline_kwargs["generate_kwargs"]["task"] = task
+            # If translate task and no explicit language provided, default to English
+            if language and language.lower() != "none":
+                pipeline_kwargs["generate_kwargs"]["language"] = language
+            elif task == "translate":
+                pipeline_kwargs["generate_kwargs"]["language"] = "en"
+        elif task != "transcribe" or language:
+            logger.warning(
+                "Generation config for model %s lacks task/language mappings; "
+                "falling back to default transcription.",
+                self.config.model_name,
+            )
 
         # Convert to WAV if extension not among standard Whisper-friendly set
         from insanely_fast_whisper_api.audio.conversion import (

--- a/tests/test_asr_backend_generation_config.py
+++ b/tests/test_asr_backend_generation_config.py
@@ -1,0 +1,48 @@
+import pathlib
+import types
+
+from insanely_fast_whisper_api.core.asr_backend import (
+    HuggingFaceBackend,
+    HuggingFaceBackendConfig,
+)
+
+
+def test_omits_task_when_generation_config_outdated(monkeypatch, tmp_path):
+    config = HuggingFaceBackendConfig(
+        model_name="dummy-model",
+        device="cpu",
+        dtype="float32",
+        batch_size=1,
+        chunk_length=30,
+    )
+    backend = HuggingFaceBackend(config)
+
+    class DummyModel:
+        generation_config = types.SimpleNamespace(task_to_id=None, lang_to_id=None)
+        config = types.SimpleNamespace(lang_to_id=None, task_to_id=None)
+
+    class DummyPipe:
+        def __init__(self):
+            self.model = DummyModel()
+
+        def __call__(self, path, **kwargs):
+            gen_kwargs = kwargs.get("generate_kwargs", {})
+            assert "task" not in gen_kwargs
+            assert "language" not in gen_kwargs
+            return {"text": "hi"}
+
+    backend.asr_pipe = DummyPipe()
+
+    monkeypatch.setattr(
+        "insanely_fast_whisper_api.audio.conversion.ensure_wav",
+        lambda p: pathlib.Path(p),
+    )
+
+    audio_file = tmp_path / "audio.wav"
+    audio_file.write_bytes(b"0")
+
+    result = backend.process_audio(
+        str(audio_file), language=None, task="translate", return_timestamps_value=False
+    )
+
+    assert result["text"] == "hi"

--- a/tests/test_asr_backend_timestamp.py
+++ b/tests/test_asr_backend_timestamp.py
@@ -1,0 +1,43 @@
+import types
+import pathlib
+
+from insanely_fast_whisper_api.core.asr_backend import HuggingFaceBackend, HuggingFaceBackendConfig
+
+
+def test_disables_timestamps_when_generation_config_missing(monkeypatch, tmp_path):
+    config = HuggingFaceBackendConfig(
+        model_name="dummy-model",
+        device="cpu",
+        dtype="float32",
+        batch_size=1,
+        chunk_length=30,
+    )
+    backend = HuggingFaceBackend(config)
+
+    class DummyModel:
+        generation_config = types.SimpleNamespace(no_timestamps_token_id=None)
+        config = types.SimpleNamespace(lang_to_id=None, task_to_id=None)
+
+    class DummyPipe:
+        def __init__(self):
+            self.model = DummyModel()
+
+        def __call__(self, path, **kwargs):
+            assert kwargs["return_timestamps"] is False
+            return {"text": "hello"}
+
+    backend.asr_pipe = DummyPipe()
+
+    monkeypatch.setattr(
+        "insanely_fast_whisper_api.audio.conversion.ensure_wav",
+        lambda p: pathlib.Path(p),
+    )
+
+    audio_file = tmp_path / "audio.wav"
+    audio_file.write_bytes(b"0")
+
+    result = backend.process_audio(
+        str(audio_file), language=None, task="transcribe", return_timestamps_value=True
+    )
+
+    assert result["chunks"] is None


### PR DESCRIPTION
## Summary
- Disable timestamp generation when model generation_config lacks required attributes
- Avoid passing task/language to models with outdated generation config
- Add unit tests for timestamp and generation-config handling

## Testing
- `pytest tests/test_asr_backend_timestamp.py tests/test_asr_backend_generation_config.py -q`
- `pytest tests/test_api.py::test_transcription_endpoint_validation -q` *(fails: FileNotFoundError: tests/data/test.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68a70ea366ac832bb35dc997b8686dd3