### PR TITLE
Replaces ghrc.io with ghcr.io

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile.dev
 
-    image: ghrc.io/beecave-homelab/insanely-fast-whisper-rocm:dev
+    image: ghcr.io/beecave-homelab/insanely-fast-whisper-rocm:dev
     # image: beecave/insanely-fast-whisper-rocm:dev
     container_name: insanely-fast-whisper-rocm-dev
     restart: unless-stopped

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
 
-    image: ghrc.io/beecave-homelab/insanely-fast-whisper-rocm:main
+    image: ghcr.io/beecave-homelab/insanely-fast-whisper-rocm:main
     # image: beecave/insanely-fast-whisper-rocm:main
     container_name: insanely-fast-whisper-rocm
     restart: unless-stopped


### PR DESCRIPTION
This PR replaces `ghrc.io` with the official `ghcr.io`. This domain is a known malicious typo-squatter.

More details here: https://bmitch.net/blog/2025-08-22-ghrc-appears-malicious/