### PR TITLE
fix: centralize environment variable access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,10 @@ WHISPER_TRANSCRIPTS_DIR=transcripts
 # Application timezone (affects filenames / logs)
 APP_TIMEZONE=Europe/Amsterdam
 
+# Eagerly close cached backend models when no borrowers remain.
+# Truthy values: 1, true, True. Default: 0 (keep models warm for reuse).
+IFW_EAGER_MODEL_RELEASE=0
+
 #------------------------------------------------------------------------------
 # Audio Chunking Configuration
 #------------------------------------------------------------------------------

--- a/insanely_fast_whisper_rocm/__main__.py
+++ b/insanely_fast_whisper_rocm/__main__.py
@@ -6,8 +6,6 @@ python -m insanely_fast_whisper_rocm
 
 import logging
 import logging.config
-import os
-import time
 from pathlib import Path
 
 import click
@@ -26,21 +24,7 @@ except ImportError:
 
 def setup_timezone() -> None:
     """Set the timezone for the application based on constants.APP_TIMEZONE."""
-    try:
-        os.environ.__setitem__("TZ", constants.APP_TIMEZONE)
-        time.tzset()
-        logging.info(
-            "Timezone set to: %s (%s) using APP_TIMEZONE='%s'",
-            time.tzname[0],
-            time.tzname[1],
-            constants.APP_TIMEZONE,
-        )
-    except (TypeError, OSError, IndexError) as exc:
-        logging.warning(
-            "Could not set timezone using APP_TIMEZONE='%s': %s. Using system default.",
-            constants.APP_TIMEZONE,
-            str(exc),
-        )
+    constants.set_app_timezone()
 
 
 def load_logging_config(debug: bool = False) -> dict:

--- a/insanely_fast_whisper_rocm/cli/cli.py
+++ b/insanely_fast_whisper_rocm/cli/cli.py
@@ -4,7 +4,6 @@ This module provides the main CLI group and coordinates all CLI functionality.
 """
 
 import logging
-import os
 import sys
 import warnings
 
@@ -25,7 +24,7 @@ logging.basicConfig(
 transformers_logging.set_verbosity_error()
 warnings.filterwarnings("ignore", category=UserWarning)
 warnings.filterwarnings("ignore", category=FutureWarning)
-os.environ["TOKENIZERS_PARALLELISM"] = "false"  # Suppress parallelism warning
+constants.set_tokenizers_parallelism()  # Suppress parallelism warning
 
 
 @click.group()

--- a/insanely_fast_whisper_rocm/core/backend_cache.py
+++ b/insanely_fast_whisper_rocm/core/backend_cache.py
@@ -23,6 +23,7 @@ from insanely_fast_whisper_rocm.core.asr_backend import (
     HuggingFaceBackendConfig,
 )
 from insanely_fast_whisper_rocm.core.pipeline import WhisperPipeline
+from insanely_fast_whisper_rocm.utils import constants
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +46,7 @@ class _CacheEntry:
 # Global cache keyed by an immutable config tuple
 _CACHE: dict[tuple[Hashable, ...], _CacheEntry] = {}
 _LOCK = threading.RLock()
-_EAGER_RELEASE = os.getenv("IFW_EAGER_MODEL_RELEASE", "0") in ("1", "true", "True")
+_EAGER_RELEASE = constants.EAGER_MODEL_RELEASE
 
 
 def _make_key(

--- a/insanely_fast_whisper_rocm/utils/constants.py
+++ b/insanely_fast_whisper_rocm/utils/constants.py
@@ -211,16 +211,16 @@ APP_TIMEZONE = os.getenv(
 def set_app_timezone() -> None:
     """Set the process timezone from centralized application configuration."""
     try:
-        os.environ.__setitem__("TZ", APP_TIMEZONE)
+        os.environ["TZ"] = APP_TIMEZONE
         time.tzset()
-        logging.info(
+        logger.info(
             "Timezone set to: %s (%s) using APP_TIMEZONE='%s'",
             time.tzname[0],
             time.tzname[1],
             APP_TIMEZONE,
         )
     except (TypeError, OSError, IndexError) as exc:
-        logging.warning(
+        logger.warning(
             "Could not set timezone using APP_TIMEZONE='%s': %s. Using system default.",
             APP_TIMEZONE,
             str(exc),

--- a/insanely_fast_whisper_rocm/utils/constants.py
+++ b/insanely_fast_whisper_rocm/utils/constants.py
@@ -98,8 +98,6 @@ _USER_CONFIG_DIR = Path.home() / ".config" / "insanely-fast-whisper-rocm"
 _USER_ENV_FILE = _USER_CONFIG_DIR / ".env"
 if (_PROJECT_ROOT / ".env").exists():
     load_dotenv(_PROJECT_ROOT / ".env", override=True)
-if not _USER_CONFIG_DIR.exists():
-    _USER_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
 if _USER_ENV_FILE.exists():
     load_dotenv(_USER_ENV_FILE, override=True)
 

--- a/insanely_fast_whisper_rocm/utils/constants.py
+++ b/insanely_fast_whisper_rocm/utils/constants.py
@@ -82,11 +82,33 @@ import sys
 import time
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
+from pathlib import Path
 from typing import Literal
 
 from dotenv import load_dotenv
 
-from insanely_fast_whisper_rocm.utils.env_loader import (
+# --- Early environment bootstrap for env_loader ---
+# env_loader is imported below for PROJECT_ROOT, USER_ENV_*, and debug_print.
+# While it is being imported it needs the effective LOG_LEVEL to decide whether
+# to enable debug printing during .env loading. Load the same .env files here
+# first and expose LOG_LEVEL before the env_loader import so env_loader can read
+# it from this module instead of accessing the environment directly.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+_USER_CONFIG_DIR = Path.home() / ".config" / "insanely-fast-whisper-rocm"
+_USER_ENV_FILE = _USER_CONFIG_DIR / ".env"
+if (_PROJECT_ROOT / ".env").exists():
+    load_dotenv(_PROJECT_ROOT / ".env", override=True)
+if not _USER_CONFIG_DIR.exists():
+    _USER_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+if _USER_ENV_FILE.exists():
+    load_dotenv(_USER_ENV_FILE, override=True)
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
+
+# env_loader is imported after the bootstrap above because env_loader itself needs
+# LOG_LEVEL (defined just above) while it initializes. Keeping this import below the
+# bootstrap avoids a circular import. noqa: E402
+from insanely_fast_whisper_rocm.utils.env_loader import (  # noqa: E402
     PROJECT_ROOT,
     USER_CONFIG_DIR,
     USER_ENV_EXISTS,
@@ -117,7 +139,7 @@ if USER_ENV_EXISTS:
 debug_print(
     f"Config loaded from .env: model={os.getenv('WHISPER_MODEL')}, "
     f"batch_size={os.getenv('WHISPER_BATCH_SIZE')}, "
-    f"log_level={os.getenv('LOG_LEVEL', 'INFO')} "
+    f"log_level={LOG_LEVEL} "
     f"(CLI flags will override when specified)"
 )
 
@@ -386,8 +408,11 @@ FILENAME_TIMEZONE = APP_TIMEZONE  # Backwards-compatible alias
 CONFIG_DIR = USER_CONFIG_DIR
 ENV_FILE = USER_ENV_FILE
 
-# Logging configuration
-LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")  # Logging level
+# The canonical LOG_LEVEL is defined earlier in this module (before env_loader is
+# imported) so env_loader can read it without directly accessing the environment.
+# The line below simply re-reads it after the final user .env load to ensure the
+# constant reflects any overrides applied above.
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 
 
 # Response formats

--- a/insanely_fast_whisper_rocm/utils/constants.py
+++ b/insanely_fast_whisper_rocm/utils/constants.py
@@ -79,6 +79,7 @@ import importlib.util
 import logging
 import os
 import sys
+import time
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
 from typing import Literal
@@ -183,6 +184,39 @@ APP_TIMEZONE = os.getenv(
     "APP_TIMEZONE",
     os.getenv("FILENAME_TIMEZONE", os.getenv("TZ", "UTC")),
 )
+
+
+def set_app_timezone() -> None:
+    """Set the process timezone from centralized application configuration."""
+    try:
+        os.environ.__setitem__("TZ", APP_TIMEZONE)
+        time.tzset()
+        logging.info(
+            "Timezone set to: %s (%s) using APP_TIMEZONE='%s'",
+            time.tzname[0],
+            time.tzname[1],
+            APP_TIMEZONE,
+        )
+    except (TypeError, OSError, IndexError) as exc:
+        logging.warning(
+            "Could not set timezone using APP_TIMEZONE='%s': %s. Using system default.",
+            APP_TIMEZONE,
+            str(exc),
+        )
+
+
+def set_tokenizers_parallelism() -> None:
+    """Disable tokenizer parallelism warnings for CLI startup."""
+    os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+
+# Eager model release mode for backend cache teardown after each borrower.
+EAGER_MODEL_RELEASE = os.getenv("IFW_EAGER_MODEL_RELEASE", "0") in (
+    "1",
+    "true",
+    "True",
+)
+
 SAVE_TRANSCRIPTIONS = (
     os.getenv("SAVE_TRANSCRIPTIONS", "true").lower() == "true"
 )  # Whether to save transcriptions to disk

--- a/insanely_fast_whisper_rocm/utils/env_loader.py
+++ b/insanely_fast_whisper_rocm/utils/env_loader.py
@@ -35,8 +35,6 @@ _project_root_env_exists_temp = PROJECT_ROOT_ENV_FILE.exists()
 if _project_root_env_exists_temp:
     load_dotenv(PROJECT_ROOT_ENV_FILE, override=True)
 
-if not USER_CONFIG_DIR.exists():
-    USER_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
 _user_env_exists_temp = USER_ENV_FILE.exists()
 if _user_env_exists_temp:
     load_dotenv(

--- a/insanely_fast_whisper_rocm/utils/env_loader.py
+++ b/insanely_fast_whisper_rocm/utils/env_loader.py
@@ -9,7 +9,6 @@ This module is responsible for:
 """
 
 import logging
-import os
 import sys
 from pathlib import Path
 
@@ -44,8 +43,15 @@ if _user_env_exists_temp:
         USER_ENV_FILE, override=True
     )  # User .env can override project for LOG_LEVEL check
 
-_env_log_level_temp = os.getenv("LOG_LEVEL", "").upper()
-_env_debug_mode_temp = _env_log_level_temp == "DEBUG"
+
+# LOG_LEVEL is owned by constants.py. Import it here (after the pre-load above) so
+# we can decide whether to enable debug printing without directly accessing the
+# process environment. This import is intentionally placed mid-module to avoid a
+# circular import: constants.py imports env_loader first, and env_loader then reads
+# the LOG_LEVEL that constants.py has already defined.
+from insanely_fast_whisper_rocm.utils.constants import LOG_LEVEL  # noqa: E402
+
+_env_debug_mode_temp = LOG_LEVEL.upper() == "DEBUG"
 
 SHOW_DEBUG_PRINTS = _cli_debug_mode or _env_debug_mode_temp
 

--- a/tests/core/test_backend_cache.py
+++ b/tests/core/test_backend_cache.py
@@ -6,7 +6,6 @@ thread safety, and resource cleanup to prevent GPU memory leaks.
 
 from __future__ import annotations
 
-import os
 import threading
 from unittest.mock import MagicMock, Mock, patch
 
@@ -18,7 +17,6 @@ from insanely_fast_whisper_rocm.core.backend_cache import (
     clear_cache,
     release_pipeline,
 )
-from insanely_fast_whisper_rocm.utils import constants
 
 
 class TestBackendCache:
@@ -133,22 +131,10 @@ class TestBackendCache:
             progress_group_size=5,
         )
 
-        # Enable eager release mode
-        with patch.dict(os.environ, {"IFW_EAGER_MODEL_RELEASE": "1"}):
-            # Re-import to pick up the environment variable
-            import importlib
-
-            from insanely_fast_whisper_rocm import core
-
-            importlib.reload(constants)
-            importlib.reload(core.backend_cache)
-            from insanely_fast_whisper_rocm.core.backend_cache import (
-                acquire_pipeline as acquire_eager,
-            )
-            from insanely_fast_whisper_rocm.core.backend_cache import (
-                release_pipeline as release_eager,
-            )
-
+        # Save the original eager-release flag and enable eager release directly.
+        original_eager_release = backend_cache._EAGER_RELEASE
+        backend_cache._EAGER_RELEASE = True
+        try:
             with patch(
                 "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"
             ) as mock_backend_class:
@@ -160,18 +146,16 @@ class TestBackendCache:
                     mock_backend_class.return_value = mock_backend
 
                     # Acquire and release
-                    pipeline, key = acquire_eager(cfg)
-                    release_eager(key)
+                    pipeline, key = acquire_pipeline(cfg)
+                    release_pipeline(key)
 
                     # Backend should have been closed
                     mock_backend.close.assert_called_once()
 
                     # Entry should be removed from cache
                     assert key not in backend_cache._CACHE
-
-            # Reload back to normal mode
-            importlib.reload(constants)
-            importlib.reload(core.backend_cache)
+        finally:
+            backend_cache._EAGER_RELEASE = original_eager_release
 
     def test_warm_cache_mode_keeps_backend(self) -> None:
         """Verify that default warm cache behavior keeps backend alive at ref_count=0."""
@@ -184,22 +168,10 @@ class TestBackendCache:
             progress_group_size=5,
         )
 
-        # Ensure eager release is off for this test
-        with patch.dict(os.environ, {"IFW_EAGER_MODEL_RELEASE": "0"}):
-            # Re-import to pick up the environment variable
-            import importlib
-
-            from insanely_fast_whisper_rocm import core
-
-            importlib.reload(constants)
-            importlib.reload(core.backend_cache)
-            from insanely_fast_whisper_rocm.core.backend_cache import (
-                acquire_pipeline as acquire_warm,
-            )
-            from insanely_fast_whisper_rocm.core.backend_cache import (
-                release_pipeline as release_warm,
-            )
-
+        # Save the original eager-release flag and disable eager release directly.
+        original_eager_release = backend_cache._EAGER_RELEASE
+        backend_cache._EAGER_RELEASE = False
+        try:
             with patch(
                 "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"
             ) as mock_backend_class:
@@ -211,8 +183,8 @@ class TestBackendCache:
                     mock_backend_class.return_value = mock_backend
 
                     # Acquire and release
-                    pipeline, key = acquire_warm(cfg)
-                    release_warm(key)
+                    pipeline, key = acquire_pipeline(cfg)
+                    release_pipeline(key)
 
                     # Backend should NOT have been closed (warm cache mode)
                     mock_backend.close.assert_not_called()
@@ -220,10 +192,8 @@ class TestBackendCache:
                     # Entry should still exist in cache
                     assert key in backend_cache._CACHE
                     assert backend_cache._CACHE[key].ref_count == 0
-
-            # Reload back to normal
-            importlib.reload(constants)
-            importlib.reload(core.backend_cache)
+        finally:
+            backend_cache._EAGER_RELEASE = original_eager_release
 
     def test_borrow_pipeline_context_manager(self) -> None:
         """Verify that borrow_pipeline context manager properly acquires and releases."""

--- a/tests/core/test_backend_cache.py
+++ b/tests/core/test_backend_cache.py
@@ -146,7 +146,7 @@ class TestBackendCache:
                     mock_backend_class.return_value = mock_backend
 
                     # Acquire and release
-                    pipeline, key = acquire_pipeline(cfg)
+                    _pipeline, key = acquire_pipeline(cfg)
                     release_pipeline(key)
 
                     # Backend should have been closed
@@ -183,7 +183,7 @@ class TestBackendCache:
                     mock_backend_class.return_value = mock_backend
 
                     # Acquire and release
-                    pipeline, key = acquire_pipeline(cfg)
+                    _pipeline, key = acquire_pipeline(cfg)
                     release_pipeline(key)
 
                     # Backend should NOT have been closed (warm cache mode)
@@ -288,7 +288,7 @@ class TestBackendCache:
                 mock_backend_class.return_value = mock_backend
 
                 # Acquire a pipeline
-                pipeline, key = acquire_pipeline(cfg)
+                _pipeline, key = acquire_pipeline(cfg)
 
                 # Clear the cache with force_close
                 clear_cache(force_close=True)
@@ -320,7 +320,7 @@ class TestBackendCache:
                 mock_backend_class.return_value = mock_backend
 
                 # Acquire a pipeline
-                pipeline, key = acquire_pipeline(cfg)
+                _pipeline, key = acquire_pipeline(cfg)
 
                 # Clear the cache with force_close (should not crash)
                 with patch(
@@ -355,7 +355,7 @@ class TestBackendCache:
                 def worker() -> None:
                     try:
                         for _ in range(10):
-                            pipeline, key = acquire_pipeline(cfg)
+                            _pipeline, key = acquire_pipeline(cfg)
                             release_pipeline(key)
                     except Exception as e:
                         errors.append(e)

--- a/tests/core/test_backend_cache.py
+++ b/tests/core/test_backend_cache.py
@@ -18,6 +18,7 @@ from insanely_fast_whisper_rocm.core.backend_cache import (
     clear_cache,
     release_pipeline,
 )
+from insanely_fast_whisper_rocm.utils import constants
 
 
 class TestBackendCache:
@@ -139,6 +140,7 @@ class TestBackendCache:
 
             from insanely_fast_whisper_rocm import core
 
+            importlib.reload(constants)
             importlib.reload(core.backend_cache)
             from insanely_fast_whisper_rocm.core.backend_cache import (
                 acquire_pipeline as acquire_eager,
@@ -168,6 +170,7 @@ class TestBackendCache:
                     assert key not in backend_cache._CACHE
 
             # Reload back to normal mode
+            importlib.reload(constants)
             importlib.reload(core.backend_cache)
 
     def test_warm_cache_mode_keeps_backend(self) -> None:
@@ -188,6 +191,7 @@ class TestBackendCache:
 
             from insanely_fast_whisper_rocm import core
 
+            importlib.reload(constants)
             importlib.reload(core.backend_cache)
             from insanely_fast_whisper_rocm.core.backend_cache import (
                 acquire_pipeline as acquire_warm,
@@ -218,6 +222,7 @@ class TestBackendCache:
                     assert backend_cache._CACHE[key].ref_count == 0
 
             # Reload back to normal
+            importlib.reload(constants)
             importlib.reload(core.backend_cache)
 
     def test_borrow_pipeline_context_manager(self) -> None:

--- a/tests/core/test_backend_cache.py
+++ b/tests/core/test_backend_cache.py
@@ -288,7 +288,7 @@ class TestBackendCache:
                 mock_backend_class.return_value = mock_backend
 
                 # Acquire a pipeline
-                _pipeline, key = acquire_pipeline(cfg)
+                _pipeline, _key = acquire_pipeline(cfg)
 
                 # Clear the cache with force_close
                 clear_cache(force_close=True)
@@ -320,7 +320,7 @@ class TestBackendCache:
                 mock_backend_class.return_value = mock_backend
 
                 # Acquire a pipeline
-                _pipeline, key = acquire_pipeline(cfg)
+                _pipeline, _key = acquire_pipeline(cfg)
 
                 # Clear the cache with force_close (should not crash)
                 with patch(


### PR DESCRIPTION
Fixes #65.\n\n## Summary\n- move IFW_EAGER_MODEL_RELEASE into utils.constants as EAGER_MODEL_RELEASE\n- move timezone and tokenizer environment mutations behind constants helpers\n- update backend-cache reload tests and document IFW_EAGER_MODEL_RELEASE in .env.example\n\n## Verification\n- pdm run ruff check insanely_fast_whisper_rocm/utils/constants.py insanely_fast_whisper_rocm/core/backend_cache.py insanely_fast_whisper_rocm/__main__.py insanely_fast_whisper_rocm/cli/cli.py tests/core/test_backend_cache.py\n- pdm run ruff format --check insanely_fast_whisper_rocm/utils/constants.py insanely_fast_whisper_rocm/core/backend_cache.py insanely_fast_whisper_rocm/__main__.py insanely_fast_whisper_rocm/cli/cli.py tests/core/test_backend_cache.py\n- pdm run python -m py_compile insanely_fast_whisper_rocm/utils/constants.py insanely_fast_whisper_rocm/core/backend_cache.py insanely_fast_whisper_rocm/__main__.py insanely_fast_whisper_rocm/cli/cli.py tests/core/test_backend_cache.py\n- git diff --check\n\n## Not run\n- pytest target tests: pytest is not installed in the current PDM environment (pdm run pytest and pdm run python -m pytest both failed). I did not install dependencies because torch/ROCm installs are forbidden in this workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized startup configuration for application timezone and tokenizer parallelism.
  * Added an explicit eager-vs-warm mode toggle for backend cache release behavior.
* **Bug Fixes**
  * Improved debug/log initialization so the configured effective log level is applied consistently across startup.
  * Ensured backend cache close/removal behavior correctly follows the selected eager/warm mode.
* **Tests**
  * Updated backend cache tests to validate eager vs warm behavior directly, without environment-variable reloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->