### PR TITLE
feat ✨: configurable idle timeout for GPU model release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,16 @@ APP_TIMEZONE=Europe/Amsterdam
 # Truthy values: 1, true, True. Default: 0 (keep models warm for reuse).
 IFW_EAGER_MODEL_RELEASE=0
 
+# Idle timeout (seconds) before releasing a cached backend model whose
+# refcount dropped to zero.  This lets you trade GPU VRAM for first-request
+# latency without choosing between indefinite caching and immediate reloads.
+#   unset/blank/malformed/negative/non-finite = disabled (model stays warm)
+#   0   = release immediately (same as IFW_EAGER_MODEL_RELEASE=1)
+#   N>0 = release after N seconds of idleness
+# IFW_EAGER_MODEL_RELEASE=1 takes precedence and always releases immediately.
+# Default: unset (disabled).
+#IFW_MODEL_RELEASE_TIMEOUT_SECONDS=300
+
 #------------------------------------------------------------------------------
 # Audio Chunking Configuration
 #------------------------------------------------------------------------------

--- a/insanely_fast_whisper_rocm/core/backend_cache.py
+++ b/insanely_fast_whisper_rocm/core/backend_cache.py
@@ -7,6 +7,12 @@ time. It exposes acquire/release helpers that manage a reference count.
 By default, entries are kept warm when their refcount drops to zero to maximize
 reuse. Set the environment variable ``IFW_EAGER_MODEL_RELEASE=1`` to eagerly
 close and remove cache entries when their refcount hits zero.
+
+Alternatively, set ``IFW_MODEL_RELEASE_TIMEOUT_SECONDS`` to a positive number
+to release the backend after that many seconds of idleness. ``0`` releases
+immediately. Unset, blank, malformed, negative, or non-finite values disable
+the timeout (the model stays warm indefinitely). Eager release takes precedence
+over the timeout and always releases immediately.
 """
 
 from __future__ import annotations
@@ -41,12 +47,15 @@ class _CacheEntry:
     backend: HuggingFaceBackend
     pipeline: WhisperPipeline
     ref_count: int = 0
+    _release_timer: threading.Timer | None = None
+    _release_generation: int = 0
 
 
 # Global cache keyed by an immutable config tuple
 _CACHE: dict[tuple[Hashable, ...], _CacheEntry] = {}
 _LOCK = threading.RLock()
 _EAGER_RELEASE = constants.EAGER_MODEL_RELEASE
+_RELEASE_TIMEOUT = constants.MODEL_RELEASE_TIMEOUT_SECONDS
 
 
 def _make_key(
@@ -75,6 +84,65 @@ def _make_key(
         bool(save_transcriptions),
         os.path.abspath(output_dir),
     )
+
+
+def _cancel_release_timer(entry: _CacheEntry) -> None:
+    """Cancel a pending delayed-release timer on *entry* if one exists."""
+    if entry._release_timer is not None:
+        entry._release_timer.cancel()
+        entry._release_timer = None
+
+
+def _schedule_release(
+    key: tuple[Hashable, ...],
+    entry: _CacheEntry,
+    timeout: float,
+) -> None:
+    """Schedule a delayed release for a zero-refcount cache entry.
+
+    Bumps the entry's release generation so any previously scheduled timer
+    is invalidated, then starts a daemon timer.
+
+    Args:
+        key: The cache key identifying the entry.
+        entry: The cache entry to release after the timeout.
+        timeout: Delay in seconds before the backend is closed.
+    """
+    _cancel_release_timer(entry)
+    entry._release_generation += 1
+    generation = entry._release_generation
+    timer = threading.Timer(timeout, _timed_release, args=(key, generation))
+    timer.daemon = True
+    entry._release_timer = timer
+    timer.start()
+
+
+def _timed_release(key: tuple[Hashable, ...], generation: int) -> None:
+    """Timer callback: close and remove a cached backend after idle timeout.
+
+    Validates the entry's identity (generation) and refcount under the lock,
+    detaches it from the cache, then closes the backend outside the lock to
+    avoid blocking other cache operations.
+
+    Args:
+        key: The cache key identifying the entry.
+        generation: The release generation captured when the timer was scheduled.
+    """
+    with _LOCK:
+        entry = _CACHE.get(key)
+        if entry is None:
+            return
+        if entry._release_generation != generation:
+            return
+        if entry.ref_count != 0:
+            return
+        _CACHE.pop(key, None)
+        entry._release_timer = None
+        backend = entry.backend
+    try:
+        backend.close()
+    except Exception as e:  # pragma: no cover - defensive cleanup
+        logger.warning("Failed to close backend during timed release: %s", e)
 
 
 def acquire_pipeline(
@@ -113,6 +181,10 @@ def acquire_pipeline(
             )
             entry = _CacheEntry(backend=backend, pipeline=pipeline, ref_count=0)
             _CACHE[key] = entry
+        else:
+            # Cancel any pending delayed release and invalidate stale timers.
+            _cancel_release_timer(entry)
+            entry._release_generation += 1
         entry.ref_count += 1
         return entry.pipeline, key
 
@@ -120,9 +192,14 @@ def acquire_pipeline(
 def release_pipeline(key: tuple[Hashable, ...]) -> None:
     """Release a previously acquired pipeline.
 
-    Decrements the reference count for the cache entry. If it reaches zero and
-    eager release is enabled (``IFW_EAGER_MODEL_RELEASE=1``), the backend is
-    closed and the entry is removed from the cache.
+    Decrements the reference count for the cache entry. If it reaches zero,
+    the backend is closed and removed according to the release policy:
+
+    - ``IFW_EAGER_MODEL_RELEASE=1``: close immediately (overrides timeout).
+    - ``IFW_MODEL_RELEASE_TIMEOUT_SECONDS`` unset/invalid: keep warm.
+    - ``IFW_MODEL_RELEASE_TIMEOUT_SECONDS=0``: close immediately.
+    - ``IFW_MODEL_RELEASE_TIMEOUT_SECONDS=N`` (positive): close after *N*
+      seconds of idleness via a cancellable background timer.
 
     Args:
         key: The cache key returned by ``acquire_pipeline``.
@@ -132,11 +209,32 @@ def release_pipeline(key: tuple[Hashable, ...]) -> None:
         if entry is None:
             return
         entry.ref_count = max(0, entry.ref_count - 1)
-        if entry.ref_count == 0 and _EAGER_RELEASE:
+        if entry.ref_count > 0:
+            return
+
+        # refcount is zero — decide release policy.
+        if _EAGER_RELEASE:
+            _cancel_release_timer(entry)
             try:
                 entry.backend.close()
             finally:
                 _CACHE.pop(key, None)
+            return
+
+        if _RELEASE_TIMEOUT is None:
+            # No timeout configured — keep the model warm.
+            return
+
+        if _RELEASE_TIMEOUT == 0:
+            _cancel_release_timer(entry)
+            try:
+                entry.backend.close()
+            finally:
+                _CACHE.pop(key, None)
+            return
+
+        # Positive timeout — schedule a delayed, cancellable release.
+        _schedule_release(key, entry, _RELEASE_TIMEOUT)
 
 
 def invalidate_gpu_cache() -> None:
@@ -151,6 +249,7 @@ def invalidate_gpu_cache() -> None:
             # The key's second element is the device string
             device = key[1]
             if isinstance(device, str) and device != "cpu":
+                _cancel_release_timer(entry)
                 try:
                     logger.info("Invalidating GPU cache entry for device: %s", device)
                     entry.backend.close()
@@ -174,6 +273,7 @@ def clear_cache(force_close: bool = False) -> None:
     with _LOCK:
         if force_close:
             for entry in _CACHE.values():
+                _cancel_release_timer(entry)
                 try:
                     entry.backend.close()
                 except Exception as e:  # pragma: no cover - defensive cleanup

--- a/insanely_fast_whisper_rocm/core/backend_cache.py
+++ b/insanely_fast_whisper_rocm/core/backend_cache.py
@@ -56,6 +56,7 @@ _CACHE: dict[tuple[Hashable, ...], _CacheEntry] = {}
 _LOCK = threading.RLock()
 _EAGER_RELEASE = constants.EAGER_MODEL_RELEASE
 _RELEASE_TIMEOUT = constants.MODEL_RELEASE_TIMEOUT_SECONDS
+_RELEASE_GENERATION = 0
 
 
 def _make_key(
@@ -93,6 +94,16 @@ def _cancel_release_timer(entry: _CacheEntry) -> None:
         entry._release_timer = None
 
 
+def _next_release_generation() -> int:
+    """Return a unique release generation.
+
+    Callers must hold ``_LOCK``.
+    """
+    global _RELEASE_GENERATION
+    _RELEASE_GENERATION += 1
+    return _RELEASE_GENERATION
+
+
 def _schedule_release(
     key: tuple[Hashable, ...],
     entry: _CacheEntry,
@@ -109,8 +120,8 @@ def _schedule_release(
         timeout: Delay in seconds before the backend is closed.
     """
     _cancel_release_timer(entry)
-    entry._release_generation += 1
-    generation = entry._release_generation
+    generation = _next_release_generation()
+    entry._release_generation = generation
     timer = threading.Timer(timeout, _timed_release, args=(key, generation))
     timer.daemon = True
     entry._release_timer = timer
@@ -184,7 +195,7 @@ def acquire_pipeline(
         else:
             # Cancel any pending delayed release and invalidate stale timers.
             _cancel_release_timer(entry)
-            entry._release_generation += 1
+            entry._release_generation = _next_release_generation()
         entry.ref_count += 1
         return entry.pipeline, key
 

--- a/insanely_fast_whisper_rocm/utils/constants.py
+++ b/insanely_fast_whisper_rocm/utils/constants.py
@@ -77,6 +77,7 @@ from __future__ import annotations
 
 import importlib.util
 import logging
+import math
 import os
 import sys
 import time
@@ -236,6 +237,28 @@ EAGER_MODEL_RELEASE = os.getenv("IFW_EAGER_MODEL_RELEASE", "0") in (
     "true",
     "True",
 )
+
+# Idle timeout (seconds) before releasing a cached backend whose refcount
+# dropped to zero.  When the env var is unset, blank, malformed, negative, or
+# non-finite, the timeout is disabled (None) and the model stays warm
+# indefinitely (the existing default behaviour).  ``0`` means immediate
+# release.  A positive value schedules a delayed release via a background
+# timer.  Eager release (``IFW_EAGER_MODEL_RELEASE=1``) takes precedence and
+# always releases immediately, regardless of this timeout.
+_raw_timeout = os.getenv("IFW_MODEL_RELEASE_TIMEOUT_SECONDS")
+MODEL_RELEASE_TIMEOUT_SECONDS: float | None
+if _raw_timeout is None or _raw_timeout.strip() == "":
+    MODEL_RELEASE_TIMEOUT_SECONDS = None
+else:
+    try:
+        _parsed_timeout = float(_raw_timeout)
+    except (ValueError, TypeError):
+        MODEL_RELEASE_TIMEOUT_SECONDS = None
+    else:
+        if _parsed_timeout < 0 or not math.isfinite(_parsed_timeout):
+            MODEL_RELEASE_TIMEOUT_SECONDS = None
+        else:
+            MODEL_RELEASE_TIMEOUT_SECONDS = _parsed_timeout
 
 SAVE_TRANSCRIPTIONS = (
     os.getenv("SAVE_TRANSCRIPTIONS", "true").lower() == "true"

--- a/tests/core/test_backend_cache_timeout.py
+++ b/tests/core/test_backend_cache_timeout.py
@@ -1,0 +1,493 @@
+"""Tests for configurable idle-timeout model release in backend_cache.
+
+Covers the ``IFW_MODEL_RELEASE_TIMEOUT_SECONDS`` feature: immediate release
+(timeout=0), delayed release via a cancellable timer, reacquire race,
+generation-guarded stale-timer suppression, eager-release precedence, and
+interaction with forceful cache clearing / GPU invalidation.
+
+The tests use a fake ``threading.Timer`` so the delayed-release callback runs
+synchronously and deterministically without real wall-clock waits.
+"""
+
+from __future__ import annotations
+
+import threading
+from importlib import reload
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from insanely_fast_whisper_rocm.core import backend_cache
+from insanely_fast_whisper_rocm.core.asr_backend import HuggingFaceBackendConfig
+from insanely_fast_whisper_rocm.core.backend_cache import (
+    acquire_pipeline,
+    borrow_pipeline,
+    clear_cache,
+    invalidate_gpu_cache,
+    release_pipeline,
+)
+
+
+def _cfg() -> HuggingFaceBackendConfig:
+    """Return a minimal backend config for cache tests."""
+    return HuggingFaceBackendConfig(
+        model_name="openai/whisper-tiny",
+        device="cpu",
+        dtype="float32",
+        batch_size=1,
+        chunk_length=30,
+        progress_group_size=5,
+    )
+
+
+class FakeTimer:
+    """Deterministic replacement for ``threading.Timer``.
+
+    The callback is stored but *not* executed until :meth:`fire` is called,
+    so tests control exactly when (or whether) the delayed release runs.
+    """
+
+    instances: list[FakeTimer] = []
+
+    def __init__(
+        self,
+        interval: float,
+        function: object,
+        args: tuple | None = None,
+        kwargs: dict | None = None,
+    ) -> None:
+        """Store the timer callback without executing it.
+
+        Args:
+            interval: Delay in seconds (unused, kept for API compatibility).
+            function: The callable to invoke on :meth:`fire`.
+            args: Positional arguments passed to *function*.
+            kwargs: Keyword arguments passed to *function*.
+        """
+        self.interval = interval
+        self.function = function
+        self.args = args or ()
+        self.kwargs = kwargs or {}
+        self.cancelled = False
+        self.started = False
+        FakeTimer.instances.append(self)
+
+    def start(self) -> None:
+        """Mark the timer as started (no thread is created)."""
+        self.started = True
+
+    def cancel(self) -> None:
+        """Mark the timer as cancelled."""
+        self.cancelled = True
+
+    def fire(self) -> None:
+        """Execute the timer callback.
+
+        Fires even if the timer was cancelled, simulating the race where
+        ``cancel()`` lost to an already-running scheduler.  The production
+        generation guard is the real defense; this just lets tests exercise
+        that defense-in-depth path.
+        """
+        self.function(*self.args, **self.kwargs)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache() -> None:
+    """Clear cache and fake-timer log before each test.
+
+    Yields:
+        None: Control back to the test; after the test, cache is re-cleared.
+    """
+    clear_cache(force_close=True)
+    FakeTimer.instances.clear()
+    yield
+    clear_cache(force_close=True)
+    FakeTimer.instances.clear()
+
+
+@pytest.fixture
+def fake_timer(monkeypatch: pytest.MonkeyPatch) -> type:
+    """Patch ``threading.Timer`` in backend_cache with FakeTimer.
+
+    Yields:
+        The FakeTimer class so tests can inspect created instances.
+    """
+    monkeypatch.setattr(backend_cache.threading, "Timer", FakeTimer)
+    yield FakeTimer
+    monkeypatch.setattr(backend_cache.threading, "Timer", threading.Timer)
+
+
+# ---------------------------------------------------------------------------
+# Constants parsing
+# ---------------------------------------------------------------------------
+
+
+class TestTimeoutParsing:
+    """Test ``IFW_MODEL_RELEASE_TIMEOUT_SECONDS`` parsing in constants.py."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (None, None),
+            ("", None),
+            ("   ", None),
+            ("abc", None),
+            ("-1", None),
+            ("-0.1", None),
+            ("inf", None),
+            ("-inf", None),
+            ("nan", None),
+            ("0", 0.0),
+            ("0.0", 0.0),
+            ("300", 300.0),
+            ("1.5", 1.5),
+        ],
+    )
+    def test_parsing(
+        self, raw: str | None, expected: float | None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify that each raw value maps to the expected parsed result."""
+        import insanely_fast_whisper_rocm.utils.constants as const_mod
+
+        if raw is None:
+            monkeypatch.delenv("IFW_MODEL_RELEASE_TIMEOUT_SECONDS", raising=False)
+        else:
+            monkeypatch.setenv("IFW_MODEL_RELEASE_TIMEOUT_SECONDS", raw)
+
+        # Reload to re-evaluate the constant.
+        reload(const_mod)
+        assert const_mod.MODEL_RELEASE_TIMEOUT_SECONDS == expected
+
+        # Restore module state for subsequent tests.
+        monkeypatch.delenv("IFW_MODEL_RELEASE_TIMEOUT_SECONDS", raising=False)
+        reload(const_mod)
+
+
+# ---------------------------------------------------------------------------
+# Backend cache timeout behavior
+# ---------------------------------------------------------------------------
+
+
+class TestTimeoutRelease:
+    """Test idle-timeout release behavior in the backend cache."""
+
+    def test_timeout_zero_releases_immediately(self) -> None:
+        """Timeout=0 closes the backend immediately on release."""
+        backend_cache._EAGER_RELEASE = False
+        backend_cache._RELEASE_TIMEOUT = 0.0
+        with (
+            patch(
+                "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"
+            ) as mb,
+            patch("insanely_fast_whisper_rocm.core.backend_cache.WhisperPipeline"),
+        ):
+            mock_backend = MagicMock()
+            mock_backend.close = Mock()
+            mb.return_value = mock_backend
+
+            _pipeline, key = acquire_pipeline(_cfg())
+            release_pipeline(key)
+
+            mock_backend.close.assert_called_once()
+            assert key not in backend_cache._CACHE
+
+    def test_positive_timeout_schedules_timer(self, fake_timer: type) -> None:
+        """A positive timeout schedules a daemon timer but does not close yet."""
+        backend_cache._EAGER_RELEASE = False
+        backend_cache._RELEASE_TIMEOUT = 300.0
+        with (
+            patch(
+                "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"
+            ) as mb,
+            patch("insanely_fast_whisper_rocm.core.backend_cache.WhisperPipeline"),
+        ):
+            mock_backend = MagicMock()
+            mock_backend.close = Mock()
+            mb.return_value = mock_backend
+
+            _pipeline, key = acquire_pipeline(_cfg())
+            release_pipeline(key)
+
+            # Entry still in cache (warm, waiting for timer).
+            assert key in backend_cache._CACHE
+            assert backend_cache._CACHE[key].ref_count == 0
+            mock_backend.close.assert_not_called()
+
+            # A timer was scheduled with the correct interval.
+            assert len(fake_timer.instances) == 1
+            timer = fake_timer.instances[0]
+            assert timer.interval == 300.0
+            assert timer.started
+            assert not timer.cancelled
+
+    def test_timer_fires_closes_and_removes(self, fake_timer: type) -> None:
+        """When the timer fires, the backend is closed and entry removed."""
+        backend_cache._EAGER_RELEASE = False
+        backend_cache._RELEASE_TIMEOUT = 60.0
+        with (
+            patch(
+                "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"
+            ) as mb,
+            patch("insanely_fast_whisper_rocm.core.backend_cache.WhisperPipeline"),
+        ):
+            mock_backend = MagicMock()
+            mock_backend.close = Mock()
+            mb.return_value = mock_backend
+
+            _pipeline, key = acquire_pipeline(_cfg())
+            release_pipeline(key)
+
+            assert len(fake_timer.instances) == 1
+            fake_timer.instances[0].fire()
+
+            mock_backend.close.assert_called_once()
+            assert key not in backend_cache._CACHE
+
+    def test_reacquire_cancels_timer(self, fake_timer: type) -> None:
+        """Reacquiring a pipeline cancels the pending release timer."""
+        backend_cache._EAGER_RELEASE = False
+        backend_cache._RELEASE_TIMEOUT = 120.0
+        with (
+            patch(
+                "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"
+            ) as mb,
+            patch("insanely_fast_whisper_rocm.core.backend_cache.WhisperPipeline"),
+        ):
+            mock_backend = MagicMock()
+            mock_backend.close = Mock()
+            mb.return_value = mock_backend
+
+            _pipeline, key = acquire_pipeline(_cfg())
+            release_pipeline(key)
+
+            timer = fake_timer.instances[0]
+            assert not timer.cancelled
+
+            # Reacquire — should cancel the timer.
+            _pipeline2, _key2 = acquire_pipeline(_cfg())
+            assert timer.cancelled
+            assert backend_cache._CACHE[key].ref_count == 1
+            mock_backend.close.assert_not_called()
+
+    def test_stale_timer_is_noop(self, fake_timer: type) -> None:
+        """A timer from a previous generation does not close the backend."""
+        backend_cache._EAGER_RELEASE = False
+        backend_cache._RELEASE_TIMEOUT = 10.0
+        with (
+            patch(
+                "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"
+            ) as mb,
+            patch("insanely_fast_whisper_rocm.core.backend_cache.WhisperPipeline"),
+        ):
+            mock_backend = MagicMock()
+            mock_backend.close = Mock()
+            mb.return_value = mock_backend
+
+            _pipeline, key = acquire_pipeline(_cfg())
+            release_pipeline(key)
+
+            stale_timer = fake_timer.instances[0]
+            stale_generation = backend_cache._CACHE[key]._release_generation
+
+            # Reacquire (bumps generation, cancels stale timer).
+            _pipeline2, _key2 = acquire_pipeline(_cfg())
+            current_gen = backend_cache._CACHE[key]._release_generation
+            assert current_gen != stale_generation
+
+            # Simulate the stale timer firing despite cancellation.
+            stale_timer.fire()
+
+            # Backend must not have been closed by the stale timer.
+            mock_backend.close.assert_not_called()
+            assert key in backend_cache._CACHE
+            assert backend_cache._CACHE[key].ref_count == 1
+
+    def test_eager_overrides_timeout(self, fake_timer: type) -> None:
+        """Eager release takes precedence over a positive timeout."""
+        backend_cache._EAGER_RELEASE = True
+        backend_cache._RELEASE_TIMEOUT = 300.0
+        with (
+            patch(
+                "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"
+            ) as mb,
+            patch("insanely_fast_whisper_rocm.core.backend_cache.WhisperPipeline"),
+        ):
+            mock_backend = MagicMock()
+            mock_backend.close = Mock()
+            mb.return_value = mock_backend
+
+            _pipeline, key = acquire_pipeline(_cfg())
+            release_pipeline(key)
+
+            mock_backend.close.assert_called_once()
+            assert key not in backend_cache._CACHE
+            # No timer should have been scheduled.
+            assert len(fake_timer.instances) == 0
+
+    def test_no_timeout_keeps_warm(self, fake_timer: type) -> None:
+        """When timeout is None, release keeps the model warm (no timer)."""
+        backend_cache._EAGER_RELEASE = False
+        backend_cache._RELEASE_TIMEOUT = None
+        with (
+            patch(
+                "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"
+            ) as mb,
+            patch("insanely_fast_whisper_rocm.core.backend_cache.WhisperPipeline"),
+        ):
+            mock_backend = MagicMock()
+            mock_backend.close = Mock()
+            mb.return_value = mock_backend
+
+            _pipeline, key = acquire_pipeline(_cfg())
+            release_pipeline(key)
+
+            mock_backend.close.assert_not_called()
+            assert key in backend_cache._CACHE
+            assert backend_cache._CACHE[key].ref_count == 0
+            assert len(fake_timer.instances) == 0
+
+    def test_borrow_pipeline_with_timeout(self, fake_timer: type) -> None:
+        """borrow_pipeline schedules a timer on exit when timeout is positive."""
+        backend_cache._EAGER_RELEASE = False
+        backend_cache._RELEASE_TIMEOUT = 45.0
+        with (
+            patch("insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"),
+            patch("insanely_fast_whisper_rocm.core.backend_cache.WhisperPipeline"),
+        ):
+            with borrow_pipeline(_cfg()):
+                pass
+
+            assert len(fake_timer.instances) == 1
+            assert not fake_timer.instances[0].cancelled
+
+
+# ---------------------------------------------------------------------------
+# Forceful clearing cancels pending timers
+# ---------------------------------------------------------------------------
+
+
+class TestForcefulClearCancelsTimers:
+    """Verify that clear_cache and invalidate_gpu_cache cancel pending timers."""
+
+    def test_clear_cache_cancels_timer(self, fake_timer: type) -> None:
+        """clear_cache(force_close=True) cancels pending release timers."""
+        backend_cache._EAGER_RELEASE = False
+        backend_cache._RELEASE_TIMEOUT = 90.0
+        with (
+            patch(
+                "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"
+            ) as mb,
+            patch("insanely_fast_whisper_rocm.core.backend_cache.WhisperPipeline"),
+        ):
+            mock_backend = MagicMock()
+            mock_backend.close = Mock()
+            mb.return_value = mock_backend
+
+            _pipeline, key = acquire_pipeline(_cfg())
+            release_pipeline(key)
+
+            timer = fake_timer.instances[0]
+            assert not timer.cancelled
+
+            clear_cache(force_close=True)
+
+            assert timer.cancelled
+            assert len(backend_cache._CACHE) == 0
+
+    def test_invalidate_gpu_cache_cancels_timer(self, fake_timer: type) -> None:
+        """invalidate_gpu_cache cancels pending release timers for GPU entries."""
+        backend_cache._EAGER_RELEASE = False
+        backend_cache._RELEASE_TIMEOUT = 90.0
+        gpu_cfg = HuggingFaceBackendConfig(
+            model_name="openai/whisper-tiny",
+            device="cuda:0",
+            dtype="float16",
+            batch_size=1,
+            chunk_length=30,
+            progress_group_size=5,
+        )
+        with (
+            patch(
+                "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"
+            ) as mb,
+            patch("insanely_fast_whisper_rocm.core.backend_cache.WhisperPipeline"),
+        ):
+            mock_backend = MagicMock()
+            mock_backend.close = Mock()
+            mb.return_value = mock_backend
+
+            _pipeline, key = acquire_pipeline(gpu_cfg)
+            release_pipeline(key)
+
+            timer = fake_timer.instances[0]
+            assert not timer.cancelled
+
+            invalidate_gpu_cache()
+
+            assert timer.cancelled
+            assert key not in backend_cache._CACHE
+
+
+# ---------------------------------------------------------------------------
+# Timer fires but entry was already removed — no error
+# ---------------------------------------------------------------------------
+
+
+class TestTimedReleaseEdgeCases:
+    """Edge cases for the timed-release callback."""
+
+    def test_timed_release_missing_entry_is_noop(self, fake_timer: type) -> None:
+        """If the entry was already removed, the timer is a no-op."""
+        backend_cache._EAGER_RELEASE = False
+        backend_cache._RELEASE_TIMEOUT = 10.0
+        with (
+            patch(
+                "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"
+            ) as mb,
+            patch("insanely_fast_whisper_rocm.core.backend_cache.WhisperPipeline"),
+        ):
+            mock_backend = MagicMock()
+            mock_backend.close = Mock()
+            mb.return_value = mock_backend
+
+            _pipeline, key = acquire_pipeline(_cfg())
+            release_pipeline(key)
+
+            timer = fake_timer.instances[0]
+
+            # Remove the entry externally (simulates concurrent clear).
+            with backend_cache._LOCK:
+                backend_cache._CACHE.pop(key, None)
+
+            # Firing the timer must not raise.
+            timer.fire()
+            mock_backend.close.assert_not_called()
+
+    def test_timed_release_nonzero_refcount_is_noop(self, fake_timer: type) -> None:
+        """If refcount is non-zero when the timer fires, it is a no-op."""
+        backend_cache._EAGER_RELEASE = False
+        backend_cache._RELEASE_TIMEOUT = 10.0
+        with (
+            patch(
+                "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"
+            ) as mb,
+            patch("insanely_fast_whisper_rocm.core.backend_cache.WhisperPipeline"),
+        ):
+            mock_backend = MagicMock()
+            mock_backend.close = Mock()
+            mb.return_value = mock_backend
+
+            _pipeline, key = acquire_pipeline(_cfg())
+            release_pipeline(key)
+
+            timer = fake_timer.instances[0]
+
+            # Reacquire (refcount goes to 1, generation bumped, old timer cancelled).
+            _pipeline2, _key2 = acquire_pipeline(_cfg())
+            assert timer.cancelled
+
+            # Firing the stale (cancelled) timer should be a no-op.
+            timer.fire()
+            mock_backend.close.assert_not_called()
+            assert key in backend_cache._CACHE
+            assert backend_cache._CACHE[key].ref_count == 1

--- a/tests/core/test_backend_cache_timeout.py
+++ b/tests/core/test_backend_cache_timeout.py
@@ -12,6 +12,7 @@ synchronously and deterministically without real wall-clock waits.
 from __future__ import annotations
 
 import threading
+from collections.abc import Callable
 from importlib import reload
 from unittest.mock import MagicMock, Mock, patch
 
@@ -117,6 +118,45 @@ def fake_timer(monkeypatch: pytest.MonkeyPatch) -> type:
     monkeypatch.setattr(backend_cache.threading, "Timer", threading.Timer)
 
 
+@pytest.fixture
+def release_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[[bool, float | None], None]:
+    """Configure release globals and restore them after the test.
+
+    Returns:
+        A function that applies eager-release and timeout values.
+    """
+
+    def configure(eager_release: bool, release_timeout: float | None) -> None:
+        """Set the release policy for the current test."""
+        monkeypatch.setattr(backend_cache, "_EAGER_RELEASE", eager_release)
+        monkeypatch.setattr(backend_cache, "_RELEASE_TIMEOUT", release_timeout)
+
+    return configure
+
+
+class TestReleasePolicyIsolation:
+    """Test release-policy overrides used by timeout tests."""
+
+    def test_release_policy__restores_globals_with_monkeypatch(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        release_policy: Callable[[bool, float | None], None],
+    ) -> None:
+        """Configured release globals are registered for automatic restoration."""
+        original_eager = backend_cache._EAGER_RELEASE
+        original_timeout = backend_cache._RELEASE_TIMEOUT
+
+        release_policy(True, 30.0)
+
+        assert backend_cache._EAGER_RELEASE is True
+        assert backend_cache._RELEASE_TIMEOUT == 30.0
+        monkeypatch.undo()
+        assert backend_cache._EAGER_RELEASE is original_eager
+        assert backend_cache._RELEASE_TIMEOUT == original_timeout
+
+
 # ---------------------------------------------------------------------------
 # Constants parsing
 # ---------------------------------------------------------------------------
@@ -171,10 +211,11 @@ class TestTimeoutParsing:
 class TestTimeoutRelease:
     """Test idle-timeout release behavior in the backend cache."""
 
-    def test_timeout_zero_releases_immediately(self) -> None:
+    def test_timeout_zero_releases_immediately(
+        self, release_policy: Callable[[bool, float | None], None]
+    ) -> None:
         """Timeout=0 closes the backend immediately on release."""
-        backend_cache._EAGER_RELEASE = False
-        backend_cache._RELEASE_TIMEOUT = 0.0
+        release_policy(False, 0.0)
         with (
             patch(
                 "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"
@@ -191,10 +232,11 @@ class TestTimeoutRelease:
             mock_backend.close.assert_called_once()
             assert key not in backend_cache._CACHE
 
-    def test_positive_timeout_schedules_timer(self, fake_timer: type) -> None:
+    def test_positive_timeout_schedules_timer(
+        self, fake_timer: type, release_policy: Callable[[bool, float | None], None]
+    ) -> None:
         """A positive timeout schedules a daemon timer but does not close yet."""
-        backend_cache._EAGER_RELEASE = False
-        backend_cache._RELEASE_TIMEOUT = 300.0
+        release_policy(False, 300.0)
         with (
             patch(
                 "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"
@@ -220,10 +262,11 @@ class TestTimeoutRelease:
             assert timer.started
             assert not timer.cancelled
 
-    def test_timer_fires_closes_and_removes(self, fake_timer: type) -> None:
+    def test_timer_fires_closes_and_removes(
+        self, fake_timer: type, release_policy: Callable[[bool, float | None], None]
+    ) -> None:
         """When the timer fires, the backend is closed and entry removed."""
-        backend_cache._EAGER_RELEASE = False
-        backend_cache._RELEASE_TIMEOUT = 60.0
+        release_policy(False, 60.0)
         with (
             patch(
                 "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"
@@ -243,10 +286,11 @@ class TestTimeoutRelease:
             mock_backend.close.assert_called_once()
             assert key not in backend_cache._CACHE
 
-    def test_reacquire_cancels_timer(self, fake_timer: type) -> None:
+    def test_reacquire_cancels_timer(
+        self, fake_timer: type, release_policy: Callable[[bool, float | None], None]
+    ) -> None:
         """Reacquiring a pipeline cancels the pending release timer."""
-        backend_cache._EAGER_RELEASE = False
-        backend_cache._RELEASE_TIMEOUT = 120.0
+        release_policy(False, 120.0)
         with (
             patch(
                 "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"
@@ -269,10 +313,11 @@ class TestTimeoutRelease:
             assert backend_cache._CACHE[key].ref_count == 1
             mock_backend.close.assert_not_called()
 
-    def test_stale_timer_is_noop(self, fake_timer: type) -> None:
+    def test_stale_timer_is_noop(
+        self, fake_timer: type, release_policy: Callable[[bool, float | None], None]
+    ) -> None:
         """A timer from a previous generation does not close the backend."""
-        backend_cache._EAGER_RELEASE = False
-        backend_cache._RELEASE_TIMEOUT = 10.0
+        release_policy(False, 10.0)
         with (
             patch(
                 "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"
@@ -302,10 +347,45 @@ class TestTimeoutRelease:
             assert key in backend_cache._CACHE
             assert backend_cache._CACHE[key].ref_count == 1
 
-    def test_eager_overrides_timeout(self, fake_timer: type) -> None:
+    def test_stale_timer_does_not_close_recreated_entry(
+        self, fake_timer: type, release_policy: Callable[[bool, float | None], None]
+    ) -> None:
+        """A stale timer cannot close a newer idle entry with the same key."""
+        release_policy(False, 10.0)
+        with (
+            patch(
+                "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"
+            ) as mb,
+            patch("insanely_fast_whisper_rocm.core.backend_cache.WhisperPipeline"),
+        ):
+            first_backend = MagicMock()
+            first_backend.close = Mock()
+            recreated_backend = MagicMock()
+            recreated_backend.close = Mock()
+            mb.side_effect = [first_backend, recreated_backend]
+
+            _pipeline, key = acquire_pipeline(_cfg())
+            release_pipeline(key)
+            stale_timer = fake_timer.instances[0]
+
+            clear_cache(force_close=True)
+            _pipeline, recreated_key = acquire_pipeline(_cfg())
+            release_pipeline(recreated_key)
+
+            assert recreated_key == key
+            assert len(fake_timer.instances) == 2
+            assert backend_cache._CACHE[key]._release_generation != stale_timer.args[1]
+
+            stale_timer.fire()
+
+            recreated_backend.close.assert_not_called()
+            assert key in backend_cache._CACHE
+
+    def test_eager_overrides_timeout(
+        self, fake_timer: type, release_policy: Callable[[bool, float | None], None]
+    ) -> None:
         """Eager release takes precedence over a positive timeout."""
-        backend_cache._EAGER_RELEASE = True
-        backend_cache._RELEASE_TIMEOUT = 300.0
+        release_policy(True, 300.0)
         with (
             patch(
                 "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"
@@ -324,10 +404,11 @@ class TestTimeoutRelease:
             # No timer should have been scheduled.
             assert len(fake_timer.instances) == 0
 
-    def test_no_timeout_keeps_warm(self, fake_timer: type) -> None:
+    def test_no_timeout_keeps_warm(
+        self, fake_timer: type, release_policy: Callable[[bool, float | None], None]
+    ) -> None:
         """When timeout is None, release keeps the model warm (no timer)."""
-        backend_cache._EAGER_RELEASE = False
-        backend_cache._RELEASE_TIMEOUT = None
+        release_policy(False, None)
         with (
             patch(
                 "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"
@@ -346,10 +427,11 @@ class TestTimeoutRelease:
             assert backend_cache._CACHE[key].ref_count == 0
             assert len(fake_timer.instances) == 0
 
-    def test_borrow_pipeline_with_timeout(self, fake_timer: type) -> None:
+    def test_borrow_pipeline_with_timeout(
+        self, fake_timer: type, release_policy: Callable[[bool, float | None], None]
+    ) -> None:
         """borrow_pipeline schedules a timer on exit when timeout is positive."""
-        backend_cache._EAGER_RELEASE = False
-        backend_cache._RELEASE_TIMEOUT = 45.0
+        release_policy(False, 45.0)
         with (
             patch("insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"),
             patch("insanely_fast_whisper_rocm.core.backend_cache.WhisperPipeline"),
@@ -369,10 +451,11 @@ class TestTimeoutRelease:
 class TestForcefulClearCancelsTimers:
     """Verify that clear_cache and invalidate_gpu_cache cancel pending timers."""
 
-    def test_clear_cache_cancels_timer(self, fake_timer: type) -> None:
+    def test_clear_cache_cancels_timer(
+        self, fake_timer: type, release_policy: Callable[[bool, float | None], None]
+    ) -> None:
         """clear_cache(force_close=True) cancels pending release timers."""
-        backend_cache._EAGER_RELEASE = False
-        backend_cache._RELEASE_TIMEOUT = 90.0
+        release_policy(False, 90.0)
         with (
             patch(
                 "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"
@@ -394,10 +477,11 @@ class TestForcefulClearCancelsTimers:
             assert timer.cancelled
             assert len(backend_cache._CACHE) == 0
 
-    def test_invalidate_gpu_cache_cancels_timer(self, fake_timer: type) -> None:
+    def test_invalidate_gpu_cache_cancels_timer(
+        self, fake_timer: type, release_policy: Callable[[bool, float | None], None]
+    ) -> None:
         """invalidate_gpu_cache cancels pending release timers for GPU entries."""
-        backend_cache._EAGER_RELEASE = False
-        backend_cache._RELEASE_TIMEOUT = 90.0
+        release_policy(False, 90.0)
         gpu_cfg = HuggingFaceBackendConfig(
             model_name="openai/whisper-tiny",
             device="cuda:0",
@@ -436,10 +520,11 @@ class TestForcefulClearCancelsTimers:
 class TestTimedReleaseEdgeCases:
     """Edge cases for the timed-release callback."""
 
-    def test_timed_release_missing_entry_is_noop(self, fake_timer: type) -> None:
+    def test_timed_release_missing_entry_is_noop(
+        self, fake_timer: type, release_policy: Callable[[bool, float | None], None]
+    ) -> None:
         """If the entry was already removed, the timer is a no-op."""
-        backend_cache._EAGER_RELEASE = False
-        backend_cache._RELEASE_TIMEOUT = 10.0
+        release_policy(False, 10.0)
         with (
             patch(
                 "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"
@@ -463,10 +548,11 @@ class TestTimedReleaseEdgeCases:
             timer.fire()
             mock_backend.close.assert_not_called()
 
-    def test_timed_release_nonzero_refcount_is_noop(self, fake_timer: type) -> None:
+    def test_timed_release_nonzero_refcount_is_noop(
+        self, fake_timer: type, release_policy: Callable[[bool, float | None], None]
+    ) -> None:
         """If refcount is non-zero when the timer fires, it is a no-op."""
-        backend_cache._EAGER_RELEASE = False
-        backend_cache._RELEASE_TIMEOUT = 10.0
+        release_policy(False, 10.0)
         with (
             patch(
                 "insanely_fast_whisper_rocm.core.backend_cache.HuggingFaceBackend"


### PR DESCRIPTION
# Pull Request: Configurable idle timeout for GPU model release

## Summary

Add `IFW_MODEL_RELEASE_TIMEOUT_SECONDS` to let users release cached GPU ASR models after a configurable idle period, balancing VRAM availability against first-request latency.

## Why

- Issue #70: the existing `IFW_EAGER_MODEL_RELEASE=1` only offers immediate release or indefinite warm caching. A persistent WebUI with `whisper-large-v3-turbo` retains ~2 GiB ROCm VRAM after work completes.
- Users need a middle ground: release the model after N seconds of idleness so short bursts of requests reuse the warm model while long gaps free VRAM.

## Notable changes (reviewer focus)

- **`constants.py`**: Parse `IFW_MODEL_RELEASE_TIMEOUT_SECONDS` with strict validation. Unset/blank/malformed/negative/non-finite values resolve to `None` (disabled, warm cache). `0` means immediate release. Positive values schedule a delayed release.
- **`backend_cache.py`**: `_CacheEntry` gains `_release_timer` and `_release_generation` fields. `release_pipeline` now follows a 3-way policy: eager (immediate, overrides timeout), `None` (warm), `0` (immediate), positive (schedule timer). The timer callback validates generation + refcount under `_LOCK`, detaches the entry, then closes the backend *outside* the lock to avoid blocking.
- **`acquire_pipeline`** cancels pending timers and bumps the generation, so a reacquire race invalidates any previously scheduled release.
- **`clear_cache` and `invalidate_gpu_cache`** cancel pending timers before closing backends (forceful paths preserved).
- **`.env.example`**: Documented the new variable with semantics and defaults.

## Files changed

- **Counts:** 4 files changed (3 modified, 1 added).
- **Key touchpoints:** `constants.py` (config parsing), `backend_cache.py` (timer lifecycle), `.env.example` (docs), `test_backend_cache_timeout.py` (new tests).

<details>
<summary>File lists (auto)</summary>

### Added
- `tests/core/test_backend_cache_timeout.py`

### Modified
- `insanely_fast_whisper_rocm/utils/constants.py`
- `insanely_fast_whisper_rocm/core/backend_cache.py`
- `.env.example`

### Deleted
- (none)

</details>

## Test plan

- [x] Unit: 25 new deterministic tests with fake `threading.Timer` covering constants parsing (12 parametrized cases), immediate/zero release, delayed timer scheduling, timer fires + close, reacquire cancels timer, stale-timer generation guard, eager precedence, warm-cache (None), borrow_pipeline timer, clear_cache cancels timer, invalidate_gpu_cache cancels timer, missing-entry and nonzero-refcount edge cases.
- [x] Regression: all 11 existing `test_backend_cache.py` tests pass unchanged.
- [x] Lint: `ruff check` and `ruff format --check` pass on all changed files.
- [ ] Integration: deferred (requires GPU/ROCm runtime; no GPU deps installed in CI container).

## Risks & rollback

- **Risks:** Timer-based release runs in a daemon thread; the generation guard prevents stale-timer races, but under extreme contention a close could race with a new acquire. Mitigated by validating under `_LOCK` and closing outside it. Default behavior (timeout unset) is unchanged.
- **Rollback:** Unset `IFW_MODEL_RELEASE_TIMEOUT_SECONDS` or revert this PR. No data migration required.

## Additional notes

- Closes #70.
- 3 pre-existing test failures (`test_srt_quality` x2, `test_env_loader` x1) are unrelated to this change and reproduce on clean `main`.
- GPU/ROCm/PyTorch runtime not available in the CI container; focused unit tests use mocks and a fake timer to verify all timer lifecycle paths deterministically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable model release timing through the `IFW_MODEL_RELEASE_TIMEOUT_SECONDS` setting.
  * Supports immediate, delayed, eager, or indefinite model retention.
  * Reacquiring a model cancels pending releases, helping prevent unnecessary reloads.

* **Bug Fixes**
  * Improved cache clearing and GPU invalidation to safely cancel scheduled releases and avoid stale model cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->